### PR TITLE
Remove underscore as dependency

### DIFF
--- a/lib/primitive_root.js
+++ b/lib/primitive_root.js
@@ -1,7 +1,5 @@
 'use strict';
 
-var _ = require('underscore');
-
 var eulerPhi = require('./euler_phi');
 var primeFactors = require('./prime_factors');
 var powerMod = require('./power_mod');
@@ -22,9 +20,14 @@ module.exports = function primitiveRoot(modulus) {
   var phi_m = eulerPhi(modulus);
   var factors = primeFactors(phi_m);
   for (var x = 2; x < modulus; x++) {
-    var check = _.every(factors, function(p) {
-      return powerMod( x, phi_m / p, modulus ) != 1;
-    })
+    var check = true;
+    var n = factors.length;
+    for (var i = 0; i < n; i++) {
+      if (powerMod(x, phi_m / factors[i], modulus) === 1) {
+        check = false;
+        break;
+      }
+    }
     if (check) { return x; }
   }
   return NaN;

--- a/lib/square_root_mod.js
+++ b/lib/square_root_mod.js
@@ -1,12 +1,11 @@
 'use strict';
 
-var _ = require('underscore');
-
 var factor = require('./factor');
 var squareRootModPrime = require('./square_root_mod_prime');
 var jacobiSymbol = require('./jacobi_symbol');
 var inverseMod = require('./inverse_mod');
 var multiplyMod = require('./multiply_mod');
+var unique = require('compute-unique');
 
 /**
  * Find all square roots of a given number n modulo m.
@@ -35,8 +34,8 @@ module.exports = function squareRootMod(n, modulus) {
       combined.unshift( r * p * inverseMod(p, m) - s * m * inverseMod(m, p) );
     });
 
-  	combined.sort();
-  	results = _.unique(combined);
+    unique(combined, false);
+    results = combined;
 
   	m = m * p;
   	var soFar = 1;

--- a/package.json
+++ b/package.json
@@ -32,9 +32,10 @@
   "devDependencies": {
     "code": "^1.4.0",
     "lab": "^5.8.1",
-    "jsdoc": "*"
+    "jsdoc": "*",
+    "underscore": "*"
   },
   "dependencies": {
-    "underscore": "*"
+    "compute-unique": "^1.0.1"
   }
 }


### PR DESCRIPTION
Love this module! Thanks for making this!

This might be a little heavy-handed—apologies!—but this PR removes underscore as a dependency (kept as devDependency) since only two functions were used. This reduces the minified bundle size from 38kb to 14kb.

Changes:
- `_.every` is just a loop with a break. Slightly more verbose, but maybe offset by saving 24kb 😄 
- `_.unique` is replaced with [`compute-unique`](https://github.com/compute-io/unique), which does precisely the same thing with only slightly different semantics.

Again, I _really_ don't mean to be the style police, but thought perhaps the bundle size savings were worthwhile. Thanks!
