### PR TITLE
Compute Mobius function for individual numbers or for a range

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,6 +198,22 @@ Solves a discrete logarithm. For more information see the following:
 * [Discrete Lograrithm](http://en.wikipedia.org/wiki/Discrete_logarithm)
 * [Baby-step Giant-step algorithm](http://en.wikipedia.org/wiki/Baby-step_giant-step)
 
+### mobius(n)
+Compute the value of the [Möbius function](https://en.wikipedia.org/wiki/M%C3%B6bius_function) for n using naive factorization. The Möbius function is defined as 1 if n is a square-free integer with an even number of prime factors, -1 if square-free with an odd number of prime factors, and 0 if n has a squared prime factor.
+
+```js
+var mobius = require('number-theory').mobius;
+mobius(30); // Returns -1
+```
+
+### mobiusRange(n1, n2[, primalityTest = miller])
+Compute the value of the [Möbius function](https://en.wikipedia.org/wiki/M%C3%B6bius_function) for integers from n1 to n2 - 1 (inclusive) using a sieve method. Compared to `mobius`, this method still effectively factors each integer but is somewhat more efficient than factoring and computing each value individually. Numbers less than min(n1, sqrt(n2)) cannot be sieved implicitly during computation, so an explicit primality test must be performed. By default, the deterministic Miller-Rabin primality test is used, but any boolean primality test may optionally be provided.
+
+```js
+var mobiusRange = require('number-theory').mobiusRange;
+mobiusRange(1000000, 1000005); // Returns [0, 1, -1, -1, 0]
+```
+
 ### miller(n), isProbablyPrime(n)
 Uses the determinisic [Miller-Rabin Primality Test](http://en.wikipedia.org/wiki/Miller%E2%80%93Rabin_primality_test)
 to determine if the given number is prime. Works for all positive integers less

--- a/index.js
+++ b/index.js
@@ -28,6 +28,8 @@ module.exports = {
   jacobiSymbol: require('./lib/jacobi_symbol'),
   logMod: require('./lib/log_mod'),
   miller: require('./lib/miller'),
+  mobius: require('./lib/mobius'),
+  mobiusRange: require('./lib/mobius-range'),
   multiplyMod: require('./lib/multiply_mod'),
   powerMod: require('./lib/power_mod'),
   primeFactors: require('./lib/prime_factors'),

--- a/lib/mobius-range.js
+++ b/lib/mobius-range.js
@@ -1,0 +1,70 @@
+'use strict';
+
+var miller = require('./miller');
+
+module.exports = function mobiusRange (n1, n2, primalityTest) {
+  var i, j, i1, i2, p, k, sqrt;
+  var n = n2 - n1;
+  var A = new Array(n);
+
+  primalityTest = primalityTest || miller;
+
+  // Initialize the output array to all ones:
+  for (i = 0; i < n; i++) {
+    A[i] = 1;
+  }
+
+  sqrt = Math.ceil(Math.sqrt(n2));
+
+  // Loop over 0 to ~sqrt(n2) and only act if p is prime:
+  for (p = 2; p < sqrt; p++) {
+    if (p < n1) {
+      // If below the lower bound of our range, we're not directly
+      // sieving, so use an external primality test:
+      if (!primalityTest(p)) {
+        continue;
+      }
+    } else if (A[p - n1] !== 1) {
+      // If within our range, we're implicitly sieving as we go,
+      // so !== 1 is sufficient to determine that p is not prime.
+      continue;
+    }
+
+    // Compute the limits relative to the prime:
+    i1 = Math.ceil(n1 / p);
+    i2 = Math.ceil(n2 / p);
+
+    for (i = i1; i < i2; i++) {
+      k = i * p;
+      if (i % p === 0) {
+        A[k - n1] = 0;
+      } else {
+        A[k - n1] *= -p;
+      }
+    }
+  }
+
+  // Analyze the results and assign values:
+  for (i = 0; i < n; i++) {
+    if (A[i] === n1 + i) {
+      A[i] = 1;
+    } else if (A[i] === -n1 - i) {
+      A[i] = -1;
+    } else if (A[i] < 0) {
+      A[i] = 1;
+    } else if (A[i] > 0) {
+      A[i] = -1;
+    } else {
+      // If the above isn't true, then this must be the case,
+      // but we'll assign explicitly to avoid negative zeros:
+      A[i] = 0;
+    }
+  }
+
+  // Handle a boundary condition when n1 === 0:
+  if (n1 === 0 && n2 > 0) {
+    A[0] = 0;
+  }
+
+  return A;
+}

--- a/lib/mobius.js
+++ b/lib/mobius.js
@@ -1,0 +1,36 @@
+'use strict';
+
+var factor = require('./factor');
+
+/**
+ * Compute the Mobius function
+ * @param {Number} n argument to compute
+ * @return The value of the mobius function for n
+ * @module number-theory
+ * @author Ricky Reusser
+ */
+module.exports = function mobius (n) {
+  // Handle zero (perhaps undefined in some sense, but this value
+  // matches Wolfram Alpha):
+  if (n === 0) {
+    return 0;
+  }
+
+  // Factor the absolute value so that negative numbers are
+  // permissible:
+  var factors = factor(Math.abs(n));
+
+  // Return zero if any factor has power > 1:
+  for (var i = 0; i < factors.length; i++) {
+    if (factors[i].power > 1) {
+      return 0;
+    }
+  }
+
+  // Otherwise return 2 if even:
+  if (factors.length % 2 === 0) {
+    return 1;
+  } else {
+    return -1;
+  }
+}

--- a/test/mobius-range.js
+++ b/test/mobius-range.js
@@ -1,0 +1,42 @@
+'use strict';
+
+var Lab = require('lab');
+var lab = exports.lab = Lab.script();
+var describe = lab.describe;
+var it = lab.it;
+var Code = require('code');
+Code.settings.comparePrototypes = false;
+var expect = Code.expect;
+
+var mobiusRange = require('../index').mobiusRange;
+
+describe('mobiusRange', function () {
+  // First fifty values of the mobius function:
+  // See: https://oeis.org/A008683
+  var values = [
+    0, 1, -1, -1, 0, -1, 1, -1, 0, 0, 1, -1, 0, -1, 1, 1, 0, -1, 0, -1,
+    0, 1, 1, -1, 0, 0, 1, 0, 0, -1, -1, -1, 0, 1, 1, 1, 0, -1, 1, 1,
+    0, -1, -1, -1, 0, 0, 1, -1, 0, 0, 0, 1, 0, -1, 0, 1, 0, 1, 1,
+    -1, 0, -1, 1, 0, 0, 1, -1, -1, 0, 1, -1, -1, 0, -1, 1, 0, 0, 1
+  ];
+
+  describe('over all possible ranges in [0, 78]', function () {
+    for (var jj = 0; jj < 78; jj++) {
+      for (var ii = 0; ii <= jj; ii++) {
+        (function(i, j) {
+          it('computes the mobius function from ' + i + ' to ' + j, function (done) {
+            expect(mobiusRange(i, j)).to.deep.equal(values.slice(i, j));
+            done();
+          });
+        }(ii, jj));
+      }
+    }
+  });
+
+  // Computed from wolfram alpha:
+  it('computes mobius from 1000000 to 1000005', function (done) {
+    expect(mobiusRange(1000000, 1000005)).to.deep.equal([0, 1, -1, -1, 0])
+    done();
+  });
+
+});

--- a/test/mobius.js
+++ b/test/mobius.js
@@ -1,0 +1,31 @@
+'use strict';
+
+var Lab = require('lab');
+var lab = exports.lab = Lab.script();
+var describe = lab.describe;
+var it = lab.it;
+var Code = require('code');
+Code.settings.comparePrototypes = false;
+var expect = Code.expect;
+
+var mobius = require('../index').mobius;
+
+describe('mobius', function () {
+  // First 77 values of the mobius function:
+  // See: https://oeis.org/A008683
+  var values = [
+    0, 1, -1, -1, 0, -1, 1, -1, 0, 0, 1, -1, 0, -1, 1, 1, 0, -1, 0, -1,
+    0, 1, 1, -1, 0, 0, 1, 0, 0, -1, -1, -1, 0, 1, 1, 1, 0, -1, 1, 1,
+    0, -1, -1, -1, 0, 0, 1, -1, 0, 0, 0, 1, 0, -1, 0, 1, 0, 1, 1,
+    -1, 0, -1, 1, 0, 0, 1, -1, -1, 0, 1, -1, -1, 0, -1, 1, 0, 0, 1
+  ];
+
+  for (var ii = 0; ii < 78; ii++) {
+    (function(i) {
+      it('computes mu(' + i + ')', function (done) {
+        expect(mobius(i)).to.deep.equal(values[i]);
+        done();
+      });
+    }(ii));
+  }
+});


### PR DESCRIPTION
I've added methods to compute the Mobius function for individual values or over a range. Rather than overloading one function, I included functions to compute either a single value (using the very naive method of full factorization) or a slightly-less naive method of performing a sieve and computing values simultaneously.

**Update**: Pardon the change to the PR. I've updated the mobius range function to actually compute it over a range of values (not just starting at zero). It's based on a combination of [stack overflow](http://mathoverflow.net/questions/99473/calculating-m%C3%B6bius-function) and the naive component of the algorithm listed in [Computing the Mertens function on a GPU](http://arxiv.org/abs/1108.0135)—but it's a bit more reasonably named now since it actually computes over a range. This change means it needs to use a deterministic primality test at times, so I plugged in the Miller-Rabin test.
